### PR TITLE
アカウントの表示名が長いとき、左側のコントロールボタン領域が折り返してしまう

### DIFF
--- a/src/popup/App.vue
+++ b/src/popup/App.vue
@@ -15,7 +15,7 @@ export default {
 
 <style>
 body{
-  width: 500px !important;
+  width: 600px !important;
   height: 500px !important;
 }
 .text-danger{

--- a/src/popup/components/Account.vue
+++ b/src/popup/components/Account.vue
@@ -85,10 +85,13 @@ export default {
 }
 .accounts .name {
   padding: 0 10px;
+  word-break: break-all;
+  flex: 1;
 }
 .accounts .edit {
   margin-left: auto;
 }
+
 .accounts .controls .button {
   margin: 0px !important;
   padding: 1rem !important;

--- a/src/popup/pages/AccountList.vue
+++ b/src/popup/pages/AccountList.vue
@@ -264,33 +264,6 @@ export default {
 </script>
 
 <style scoped>
-.accounts {
-  display: flex;
-  align-items: center;
-  margin: 5px;
-  padding: 2px 10px;
-}
-.accounts .name {
-  padding: 0 10px;
-  word-break: break-all;
-}
-.accounts .edit {
-  margin-left: auto;
-}
-.group-header .controls {
-  margin-left: auto;
-}
-.group-header .button {
-  margin: 0px 5px 10px 5px !important;
-  padding: 0.5rem !important;
-}
-.accounts .controls {
-  width: 130px;
-}
-.accounts .controls .button {
-  margin: 0px !important;
-  padding: 1rem !important;
-}
 .header {
   position: sticky;
   top: 0.75rem;


### PR DESCRIPTION
Fixes #42