### PR TITLE
Sandbox環境が開けない

### DIFF
--- a/src/entity/SfConnection.js
+++ b/src/entity/SfConnection.js
@@ -2,8 +2,10 @@ import jsforce from 'jsforce'
 
 
 export default class SfConnection {
-    constructor(){
-        this._conn = new jsforce.Connection();
+    constructor(orgType){
+        this._conn = new jsforce.Connection({
+            loginUrl: `https://${orgType === 'sandbox' ? 'test' : 'login'}.salesforce.com`
+        });
     }
 
     login(account, redirectUrl){

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -28,7 +28,8 @@
   "permissions": [
     "storage",
     "background",
-    "https://login.salesforce.com/"
+    "https://login.salesforce.com/",
+    "https://test.salesforce.com/"
   ],
   "commands": {
     "_execute_browser_action": {

--- a/src/popup/pages/AccountList.vue
+++ b/src/popup/pages/AccountList.vue
@@ -139,13 +139,13 @@ export default {
       this.$store.dispatch('resetAccounts', this._flatGroupedAccounts)
     },
     openHome(account) {
-      new SfConnection().login(account, '/lightning/page/home')
+      new SfConnection(account.orgType).login(account, '/lightning/page/home')
     },
     openDevConsole(account) {
-      new SfConnection().login(account, '/_ui/common/apex/debug/ApexCSIPage')
+      new SfConnection(account.orgType).login(account, '/_ui/common/apex/debug/ApexCSIPage')
     },
     openSetup(account) {
-      new SfConnection().login(account, '/lightning/setup/SetupOneHome/home')
+      new SfConnection(account.orgType).login(account, '/lightning/setup/SetupOneHome/home')
     },
     keyboardAction(event) {
       switch (event.srcKey) {


### PR DESCRIPTION
Fixes #58

orgTypeがsandboxの場合はtest.salesforce.comにログインするようにした。それ以外はlogin.salesforce.com固定。